### PR TITLE
Add URL navigation

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -10,7 +10,9 @@
     "dependencies": {
         "elm-lang/core": "4.0.0 <= v < 5.0.0",
         "elm-lang/html": "1.0.0 <= v < 2.0.0",
-        "evancz/elm-http": "3.0.1 <= v < 4.0.0"
+        "evancz/elm-http": "3.0.1 <= v < 4.0.0",
+        "elm-lang/navigation": "1.0.0 <= v < 2.0.0",
+        "evancz/url-parser": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/src/Components/Breadcrumbs.elm
+++ b/src/Components/Breadcrumbs.elm
@@ -1,0 +1,53 @@
+module Components.Breadcrumbs exposing (..)
+
+import Html exposing (..)
+import Html.Attributes exposing (..)
+import Html.Events exposing (onClick)
+import List
+
+import Msg exposing (..)
+import Page exposing (..)
+import Models exposing (..)
+
+
+type alias Breadcrumb =
+  { name : String
+  , page : Maybe Page
+  }
+
+
+renderBreadcrumbs : List Breadcrumb -> Html Msg
+renderBreadcrumbs breadcrumbs =
+  let
+    render breadcrumb = case breadcrumb.page of
+       Just page ->
+        li
+          []
+          [ a [ pointer
+              , onClick (NewPage page)]
+              [ text breadcrumb.name ]
+          ]
+       Nothing ->
+         li
+           [ class "active" ]
+           [ text breadcrumb.name ]
+  in ol
+    [ class "breadcrumb" ]
+    (List.map render breadcrumbs)
+
+
+breadCrumbs : AppModel -> Html Msg
+breadCrumbs model =
+  let
+    home = [Breadcrumb "Home" (Just Home)]
+    breadcrumbs = case model.currentPage of
+      Home ->
+        []
+      NewProject ->
+        [ Breadcrumb "New Project" Nothing ]
+      Project project ->
+        [ Breadcrumb project Nothing ]
+      Jobset project jobset ->
+        [ Breadcrumb project Nothing
+        , Breadcrumb jobset (Just model.currentPage) ]
+  in renderBreadcrumbs (home ++ breadcrumbs)

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -17,14 +17,14 @@ import Urls exposing (urlParser)
 init : Result String Page -> ( AppModel, Cmd Msg )
 init result =
   let
-   (model, cmds) = urlUpdate result (initialModel Page.Home)
-  in ( model, Cmd.batch [ doInit
-                        , cmds ] )
+   (model, cmds) = urlUpdate result initialModel
+  in model ! [ doInit, cmds ]
 
 
 doInit : Cmd Msg
 doInit =
   Task.perform FetchFail FetchSucceed (Http.get decodeInit "/api/init")
+
 
 decodeInit : Json.Decoder (String)
 decodeInit = Json.succeed "a"
@@ -32,6 +32,12 @@ decodeInit = Json.succeed "a"
 --    |: ("id" := Json.int)
 --    |: ("title" := Json.string)
 --  )
+
+
+subscriptions : AppModel -> Sub Msg
+subscriptions model =
+  Sub.none
+
 
 main : Program Never
 main =
@@ -42,7 +48,3 @@ main =
     , urlUpdate = urlUpdate
     , subscriptions = subscriptions
     }
-
-subscriptions : AppModel -> Sub Msg
-subscriptions model =
-  Sub.none

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,20 +1,25 @@
 module Main exposing (..)
 
-import Html.App as Html
-import Task
 import Http
+import Task
 import Json.Decode as Json
 import Json.Decode exposing ((:=))
+import Navigation
 
 import Msg exposing (..)
 import Models exposing (..)
+import Page exposing (Page)
 import Update exposing (..)
 import View exposing (..)
+import Urls exposing (urlParser)
 
 
-init : ( AppModel, Cmd Msg )
-init = ( initialModel, Cmd.batch [ title "Projects"
-                                 , doInit ] )
+init : Result String Page -> ( AppModel, Cmd Msg )
+init result =
+  let
+   (model, cmds) = urlUpdate result (initialModel Page.Home)
+  in ( model, Cmd.batch [ doInit
+                        , cmds ] )
 
 
 doInit : Cmd Msg
@@ -30,10 +35,11 @@ decodeInit = Json.succeed "a"
 
 main : Program Never
 main =
-  Html.program
+  Navigation.program (Navigation.makeParser urlParser)
     { init = init
     , update = update
     , view = view
+    , urlUpdate = urlUpdate
     , subscriptions = subscriptions
     }
 

--- a/src/Models.elm
+++ b/src/Models.elm
@@ -3,8 +3,10 @@ module Models exposing (..)
 import Page exposing (..)
 
 
+type AlertType = Danger | Info | Warning | Success
+
 type alias Alert =
-  { kind : String
+  { kind : AlertType
   , msg : String
   }
 

--- a/src/Models.elm
+++ b/src/Models.elm
@@ -58,11 +58,11 @@ type alias AppModel =
   }
 
 
-initialModel : Page -> AppModel
-initialModel page =
+initialModel : AppModel
+initialModel =
   { alert = Nothing
   , user = Nothing
-  , currentPage = page
+  , currentPage = Page.Home
   , searchString = ""
   , hydraConfig =
     -- TODO: downsize logo, serve it with webpack

--- a/src/Models.elm
+++ b/src/Models.elm
@@ -1,5 +1,8 @@
 module Models exposing (..)
 
+import Page exposing (..)
+
+
 type alias Alert =
   { kind : String
   , msg : String
@@ -51,13 +54,15 @@ type alias AppModel =
   , user : Maybe User
   , queueStats : QueueStats
   , searchString : String
+  , currentPage : Page
   }
 
 
-initialModel : AppModel
-initialModel =
+initialModel : Page -> AppModel
+initialModel page =
   { alert = Nothing
   , user = Nothing
+  , currentPage = page
   , searchString = ""
   , hydraConfig =
     -- TODO: downsize logo, serve it with webpack

--- a/src/Msg.elm
+++ b/src/Msg.elm
@@ -17,3 +17,4 @@ type Msg
   | PreferencesClick
   | LiveSearchMsg LiveSearch.Msg
   | NewPage Page.Page
+  | ClickCreateProject

--- a/src/Msg.elm
+++ b/src/Msg.elm
@@ -3,7 +3,7 @@ module Msg exposing (..)
 import Http
 
 import LiveSearch
-
+import Page
 
 type LoginType
   = Hydra
@@ -16,3 +16,4 @@ type Msg
   | LogoutUserClick
   | PreferencesClick
   | LiveSearchMsg LiveSearch.Msg
+  | NewPage Page.Page

--- a/src/Page.elm
+++ b/src/Page.elm
@@ -1,9 +1,17 @@
 module Page exposing (..)
 
+import Html
+import Html.Attributes exposing (style)
+
+
 {-| Main type representing current url/page
 -}
-
 type Page
   = Home
   | Project String
+  | NewProject
   | Jobset String String
+
+
+pointer : Html.Attribute a
+pointer = style [("cursor", "pointer")]

--- a/src/Page.elm
+++ b/src/Page.elm
@@ -12,6 +12,6 @@ type Page
   | NewProject
   | Jobset String String
 
-
+{-| typically used to simuate a link -}
 pointer : Html.Attribute a
 pointer = style [("cursor", "pointer")]

--- a/src/Page.elm
+++ b/src/Page.elm
@@ -1,0 +1,9 @@
+module Page exposing (..)
+
+{-| Main type representing current url/page
+-}
+
+type Page
+  = Home
+  | Project String
+  | Jobset String String

--- a/src/Update.elm
+++ b/src/Update.elm
@@ -57,13 +57,19 @@ update msg model =
 
 urlUpdate : Result String Page -> AppModel -> (AppModel, Cmd b)
 urlUpdate result model =
-  case Debug.log "urlUpdate" result of
-    Err _ ->
-      -- TODO: render alert box here
-      ( model, Cmd.none )
+  case result of
+    Err msg ->
+      let
+        msg = (Debug.log "urlUpdate:" msg)
+        alert = { kind = Danger
+                , msg = "Given URL returned 404."
+                }
+      in { model| alert = Just alert} ! []
 
     Ok page ->
-      ( { model | currentPage = page }, title (pageToTitle page) )
+    ( { model | currentPage = page
+      , alert = Nothing }
+    , title (pageToTitle page) )
 
 
 

--- a/src/Update.elm
+++ b/src/Update.elm
@@ -1,8 +1,12 @@
 port module Update exposing (..)
 
+import Navigation
+
 import Models exposing (..)
 import Msg exposing (..)
 import LiveSearch
+import Page exposing (..)
+import Urls exposing (pageToURL, pageToTitle)
 
 
 update : Msg -> AppModel -> ( AppModel, Cmd Msg )
@@ -14,7 +18,6 @@ update msg model =
 
     FetchFail msg ->
       ( model, popoverInit ())
-
 
     LoginUserClick loginType ->
         let
@@ -43,6 +46,21 @@ update msg model =
       let
         (newmodel, cmds) = LiveSearch.update searchmsg model
       in (newmodel, Cmd.map LiveSearchMsg cmds)
+
+    NewPage page ->
+      ( model, Navigation.newUrl (pageToURL page))
+
+
+urlUpdate : Result String Page -> AppModel -> (AppModel, Cmd b)
+urlUpdate result model =
+  case Debug.log "urlUpdate" result of
+    Err _ ->
+      -- TODO: render alert box here
+      ( model, Cmd.none )
+
+    Ok page ->
+      ( { model | currentPage = page }, title (pageToTitle page) )
+
 
 
 -- Ports

--- a/src/Update.elm
+++ b/src/Update.elm
@@ -50,6 +50,10 @@ update msg model =
     NewPage page ->
       ( model, Navigation.newUrl (pageToURL page))
 
+    ClickCreateProject ->
+      -- TODO: http
+      ( model, Cmd.none )
+
 
 urlUpdate : Result String Page -> AppModel -> (AppModel, Cmd b)
 urlUpdate result model =

--- a/src/Urls.elm
+++ b/src/Urls.elm
@@ -19,6 +19,7 @@ pageParser =
   oneOf
     [ format Home (s "")
     , format Project (s "project" </> string)
+    , format NewProject (s "create-project")
     , format Jobset (s "jobset" </> string </> string)
     ]
 
@@ -28,6 +29,7 @@ pageToURL page =
   case page of
     Home -> "/"
     Project name -> "/project/" ++ name
+    NewProject -> "/create-project"
     Jobset project jobset -> "/jobset/" ++ project ++ "/" ++ jobset
 
 
@@ -36,4 +38,5 @@ pageToTitle page =
    case page of
      Home -> "Projects"
      Project name -> "Project " ++ name
+     NewProject -> "New Project"
      Jobset project jobset -> "Jobset " ++ jobset ++ " of project " ++ project

--- a/src/Urls.elm
+++ b/src/Urls.elm
@@ -1,0 +1,39 @@
+module Urls exposing (..)
+
+import Debug
+import Navigation
+import Page exposing (..)
+import String
+import UrlParser exposing (Parser, (</>), format, int, oneOf, s, string)
+
+
+urlParser : Navigation.Location -> Result String Page
+urlParser location =
+  String.dropLeft 1 location.pathname
+   |> Debug.log "pathname"
+   |> UrlParser.parse identity pageParser
+
+
+pageParser : Parser (Page -> a) a
+pageParser =
+  oneOf
+    [ format Home (s "")
+    , format Project (s "project" </> string)
+    , format Jobset (s "jobset" </> string </> string)
+    ]
+
+
+pageToURL : Page -> String
+pageToURL page =
+  case page of
+    Home -> "/"
+    Project name -> "/project/" ++ name
+    Jobset project jobset -> "/jobset/" ++ project ++ "/" ++ jobset
+
+
+pageToTitle : Page -> String
+pageToTitle page =
+   case page of
+     Home -> "Projects"
+     Project name -> "Project " ++ name
+     Jobset project jobset -> "Jobset " ++ jobset ++ " of project " ++ project

--- a/src/Utils.elm
+++ b/src/Utils.elm
@@ -21,3 +21,11 @@ optionalTag : Bool -> Html Msg -> Html Msg
 optionalTag doInclude html
   = if doInclude
     then html else text ""
+
+
+render404 : String -> List (Html Msg)
+render404 reason =
+  [ p
+    [ class "text-center lead"]
+    [ text reason ]
+  ]

--- a/src/View.elm
+++ b/src/View.elm
@@ -71,6 +71,12 @@ alertView alert =
   case alert of
     Nothing -> div [] []
     Just value ->
-      div
-      [ class ("alert alert-" ++ value.kind) ]
-      [ text ("Error: " ++ value.msg) ]
+      let
+        kind = case value.kind of
+          Danger -> "danger"
+          Success -> "success"
+          Info -> "info"
+          Warning -> "warning"
+      in div
+           [ class ("alert alert-" ++ kind) ]
+           [ text ("Error: " ++ value.msg) ]

--- a/src/View.elm
+++ b/src/View.elm
@@ -7,7 +7,7 @@ import List
 
 import Msg exposing (Msg)
 import Models exposing (..)
-import Views.Project exposing (projectView, projectsView)
+import Views.Project exposing (projectView, projectsView, newProjectView)
 import Views.Navbar exposing (navbarView)
 import Page exposing (..)
 import Utils exposing (..)
@@ -21,10 +21,13 @@ view model =
     , div
       [ class "container" ]
       -- TODO: breadcrumbs
-      ([ alertView model.alert ]
-      ++ pageToView model ++
-      [ footer
-        [ class "text-center" ]
+      [ (alertView model.alert)
+      , div
+          [ class "row" ]
+          (pageToView model)
+      , footer
+        [ class "text-center"
+        , style [("margin-top", "30px")] ]
         [ small
           []
           [ a
@@ -44,7 +47,7 @@ view model =
               ]
           ]
         ]
-      ])
+      ]
     ]
 
 
@@ -57,6 +60,8 @@ pageToView model =
       case List.head (List.filter (\p -> p.name == name) model.projects) of
         Just project -> projectView project
         Nothing -> render404 ("Project " ++ name ++ " does not exist.")
+    NewProject ->
+      newProjectView model
     Jobset project jobset ->
       []
 

--- a/src/View.elm
+++ b/src/View.elm
@@ -5,6 +5,7 @@ import Html.Attributes exposing (..)
 import Maybe
 import List
 
+import Components.Breadcrumbs exposing (breadCrumbs)
 import Msg exposing (Msg)
 import Models exposing (..)
 import Views.Project exposing (projectView, projectsView, newProjectView)
@@ -20,8 +21,8 @@ view model =
     [ navbarView model
     , div
       [ class "container" ]
-      -- TODO: breadcrumbs
       [ (alertView model.alert)
+      , (breadCrumbs model)
       , div
           [ class "row" ]
           (pageToView model)
@@ -64,6 +65,7 @@ pageToView model =
       newProjectView model
     Jobset project jobset ->
       []
+
 
 
 alertView : Maybe Alert -> Html Msg

--- a/src/View.elm
+++ b/src/View.elm
@@ -5,40 +5,24 @@ import Html.Attributes exposing (..)
 import Maybe
 import List
 
-import Msg exposing (..)
+import Msg exposing (Msg)
 import Models exposing (..)
-import LiveSearch
-import Views.Project exposing (projectView)
+import Views.Project exposing (projectView, projectsView)
 import Views.Navbar exposing (navbarView)
+import Page exposing (..)
 import Utils exposing (..)
 
 
 view : AppModel -> Html Msg
 view model =
-  let
-    projects = List.map projectView (LiveSearch.search model.projects)
-  in div
+  div
     []
     [ navbarView model
     , div
       [ class "container" ]
       -- TODO: breadcrumbs
-      ([ alertView model.alert
-      , h1
-          []
-          [ text "Projects "
-          , button
-              [ type' "submit"
-              , class "btn btn-primary" ]
-              [ fontAwesome "plus-circle fa-lg"
-              , text " New" ]
-          ]
-      , br [] []
-      ] ++ if List.isEmpty projects
-           then [ p
-                    [ class "text-center lead" ]
-                    [ text "Zero projects. Maybe add one?" ] ]
-           else projects ++
+      ([ alertView model.alert ]
+      ++ pageToView model ++
       [ footer
         [ class "text-center" ]
         [ small
@@ -62,6 +46,20 @@ view model =
         ]
       ])
     ]
+
+
+pageToView : AppModel -> List (Html Msg)
+pageToView model =
+  case model.currentPage of
+    Home ->
+      projectsView model.projects
+    Project name ->
+      case List.head (List.filter (\p -> p.name == name) model.projects) of
+        Just project -> projectView project
+        Nothing -> render404 ("Project " ++ name ++ " does not exist.")
+    Jobset project jobset ->
+      []
+
 
 alertView : Maybe Alert -> Html Msg
 alertView alert =

--- a/src/Views/Navbar.elm
+++ b/src/Views/Navbar.elm
@@ -85,6 +85,7 @@ navbarView model =
             , a
               [ class "navbar-brand"
               , onClick (NewPage Page.Home)
+              , Page.pointer
               , style [("padding", "0")]
               ]
               [ if model.hydraConfig.logo == ""

--- a/src/Views/Navbar.elm
+++ b/src/Views/Navbar.elm
@@ -8,6 +8,7 @@ import Html.Events exposing (onClick)
 import Msg exposing (..)
 import Models exposing (AppModel)
 import LiveSearch
+import Page exposing (Page)
 import Utils exposing (..)
 
 
@@ -83,7 +84,7 @@ navbarView model =
               ]
             , a
               [ class "navbar-brand"
-              , href "c.uri_for(c.controller('Root').action_for('index'))"
+              , onClick (NewPage Page.Home)
               , style [("padding", "0")]
               ]
               [ if model.hydraConfig.logo == ""
@@ -128,7 +129,7 @@ navbarView model =
                     , ul [ class "dropdown-menu" ]
                         [ li
                             []
-                            [ a [ href "#" ]
+                            [ a [ ]
                                 [ text "Builds in progress "
                                 , span
                                     [ class "label label-primary" ]

--- a/src/Views/Project.elm
+++ b/src/Views/Project.elm
@@ -2,21 +2,46 @@ module Views.Project exposing (..)
 
 import Html exposing (..)
 import Html.Attributes exposing (..)
+import Html.Events exposing (onClick)
 import List
 
 import Msg exposing (..)
 import Models exposing (Project)
+import Page exposing (Page)
 import LiveSearch
 import Utils exposing (..)
 import Components.Help exposing (..)
 
 
-projectView : Project -> Html Msg
-projectView project =
+projectsView : List Project -> List (Html Msg)
+projectsView projects =
+    let
+      newprojects = List.map renderProject (LiveSearch.search projects)
+    in
+    [ h1
+        [ style [("margin-bottom", "30px")]]
+        [ text "Projects "
+        , button
+            [ type' "submit"
+            , class "btn btn-primary" ]
+            [ fontAwesome "plus-circle fa-lg"
+            , text " New" ]
+        ]
+    ] ++ if List.isEmpty newprojects
+         then render404 "Zero projects. Maybe add one?"
+         else newprojects
+
+projectView : Project -> List (Html Msg)
+projectView project = [renderProject project]
+
+
+renderProject : Project -> Html Msg
+renderProject project =
   div
     [ class "panel panel-default" ]
-    [ div
-      [ class "panel-heading clearfix" ]
+    [ a
+      [ class "panel-heading clearfix btn-block"
+      , onClick (NewPage (Page.Project project.name)) ]
       [ span
         [ class "lead" ]
         [ text (project.name ++ " ") ]

--- a/src/Views/Project.elm
+++ b/src/Views/Project.elm
@@ -3,10 +3,11 @@ module Views.Project exposing (..)
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (onClick)
+import Maybe
 import List
 
 import Msg exposing (..)
-import Models exposing (Project)
+import Models exposing (Project, AppModel)
 import Page exposing (Page)
 import LiveSearch
 import Utils exposing (..)
@@ -23,7 +24,8 @@ projectsView projects =
         [ text "Projects "
         , button
             [ type' "submit"
-            , class "btn btn-primary" ]
+            , class "btn btn-primary"
+            , onClick (NewPage Page.NewProject) ]
             [ fontAwesome "plus-circle fa-lg"
             , text " New" ]
         ]
@@ -31,8 +33,109 @@ projectsView projects =
          then render404 "Zero projects. Maybe add one?"
          else newprojects
 
+
 projectView : Project -> List (Html Msg)
 projectView project = [renderProject project]
+
+
+newProjectView : AppModel -> List (Html Msg)
+newProjectView model =
+  [ h1
+      [ style [("margin-bottom", "30px")] ]
+      [ text "Add a new project" ]
+  , Html.form
+      [ class "row col-xs-6"]
+      [ div
+          [ class "form-group" ]
+          [ label
+              [ ]
+              [ text "Identifier" ]
+          , input
+              [ class "form-control"
+              , placeholder "e.g. hydra"
+              , type' "text"
+              ]
+              []
+          ]
+      , div
+          [ class "form-group" ]
+          [ label
+              [ ]
+              [ text "Display Name" ]
+          , input
+              [ class "form-control"
+              , placeholder "e.g. Hydra"
+              , type' "text"
+              ]
+              []
+          ]
+      , div
+          [ class "form-group" ]
+          [ label
+              [ ]
+              [ text "Description" ]
+          , input
+              [ class "form-control"
+              , placeholder "e.g. Builds Nix expressions and provides insight about the process"
+              , type' "text"
+              ]
+              []
+          ]
+      , div
+          [ class "form-group" ]
+          [ label
+              [ ]
+              [ text "Homepage" ]
+          , input
+              [ class "form-control"
+              , placeholder "e.g. https://github.com/NixOS/hydra"
+              , type' "text"
+              ]
+              []
+          ]
+      , div
+          [ class "form-group" ]
+          [ label
+              [ ]
+              [ text "Owner" ]
+          , input
+              [ class "form-control"
+              , type' "text"
+              , value (Maybe.withDefault "" (Maybe.map (\u -> u.id )model.user))
+              ]
+              []
+          ]
+      , div
+          [ class "checkbox" ]
+          [ label
+              []
+              [ input
+                  [ type' "checkbox"
+                  , checked True ]
+                  []
+              , text "Is visible on the project list?"
+              ]
+          ]
+      , div
+          [ class "checkbox" ]
+          [ label
+              []
+              [ input
+                  [ type' "checkbox"
+                  , checked True ]
+                  []
+              , text "Is enabled?"
+              ]
+          ]
+      , button
+          [ type' "submit"
+          , class "btn btn-primary btn-lg"
+          , style [("margin-top", "30px")]
+          , onClick ClickCreateProject ]
+          [ fontAwesome "plus-circle fa-lg"
+          , text " Create project" ]
+      ]
+  ]
 
 
 renderProject : Project -> Html Msg
@@ -41,6 +144,7 @@ renderProject project =
     [ class "panel panel-default" ]
     [ a
       [ class "panel-heading clearfix btn-block"
+      , Page.pointer
       , onClick (NewPage (Page.Project project.name)) ]
       [ span
         [ class "lead" ]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,5 +42,6 @@ module.exports = {
   devServer: {
     inline: true,
     stats: { colors: true },
+    historyApiFallback: true
   },
 };


### PR DESCRIPTION
We're now using the very fresh [navigation](http://package.elm-lang.org/packages/elm-lang/navigation/1.0.0/) and [url-parser](http://package.elm-lang.org/packages/evancz/url-parser/1.0.0/) packages.

#### Highlights

- `AppModel.currentPage` defines the page we're on
- `Msg.NewPage Page` denotes we're switcing to the new page
- `pageToUrl` generates an url out of `Page`
- `pageParsers` generates `Page` out of an url
- `pageToTitle` generates document.title for each `Page`
- `projectView` sits besides projectsView and you can navigate
  between them!

#### TODO

- figure out breadcrumbs using `pageToBreadCrumbs : AppModel -> Page ->
  Breadcrumbs`